### PR TITLE
Ability to disable blueprint

### DIFF
--- a/flask_bitmapist/core.py
+++ b/flask_bitmapist/core.py
@@ -51,4 +51,6 @@ class FlaskBitmapist(object):
             app.extensions = {}
 
         app.extensions['bitmapist'] = self
-        app.register_blueprint(bitmapist_bp)
+
+        if not app.config.get('DISABLE_BLUEPRINT'):
+            app.register_blueprint(bitmapist_bp)


### PR DESCRIPTION
Set app.config['DISABLE_BLUEPRINT'] to True in order to disable blueprint. Otherwise, blueprint is enabled.
